### PR TITLE
Update ann_exception.h

### DIFF
--- a/include/ann_exception.h
+++ b/include/ann_exception.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
+#include <stdint.h>
 #include <string>
 #include <stdexcept>
 #include <system_error>


### PR DESCRIPTION
#### What does this implement/fix? Briefly explain your changes.
The error produced by `mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j 1`:
```
/aisaq-diskann/include/ann_exception.h:22:65: error: ‘uint32_t’ has not been declared
   22 |                                    const std::string &fileName, uint32_t lineNum);
      |                                                                 ^~~~~~~~
compilation terminated due to -Wfatal-errors.
make[2]: *** [src/CMakeFiles/diskann.dir/build.make:90: src/CMakeFiles/diskann.dir/ann_exception.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:254: src/CMakeFiles/diskann.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

